### PR TITLE
 RS-658: add automatic to schema implementation for butane generic dependent structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,10 +92,10 @@ checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
 name = "butane"
-version = "0.5.2-alpha.5"
+version = "0.5.2-alpha.6"
 dependencies = [
- "butane_codegen 0.5.1-alpha.5 (registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git)",
- "butane_core 0.5.2-alpha.4 (registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git)",
+ "butane_codegen",
+ "butane_core",
  "cfg-if",
  "chrono",
  "env_logger",
@@ -116,21 +116,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "butane"
-version = "0.5.2-alpha.5"
-source = "registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git"
-checksum = "7e414a26e5f00315e7c2cf517e654426aa38f6fe15b4e8eb9ae22c1ee071a411"
-dependencies = [
- "butane_codegen 0.5.1-alpha.5 (registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git)",
- "butane_core 0.5.2-alpha.4 (registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git)",
-]
-
-[[package]]
 name = "butane_cli"
-version = "0.5.2-alpha.5"
+version = "0.5.2-alpha.6"
 dependencies = [
  "anyhow",
- "butane 0.5.2-alpha.5 (registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git)",
+ "butane",
  "chrono",
  "clap",
  "quote 1.0.23",
@@ -140,22 +130,9 @@ dependencies = [
 
 [[package]]
 name = "butane_codegen"
-version = "0.5.1-alpha.5"
+version = "0.5.1-alpha.6"
 dependencies = [
- "butane_core 0.5.2-alpha.4 (registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git)",
- "proc-macro2 1.0.49",
- "quote 1.0.23",
- "syn 1.0.107",
- "uuid",
-]
-
-[[package]]
-name = "butane_codegen"
-version = "0.5.1-alpha.5"
-source = "registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git"
-checksum = "557c0c0896f1ba6ecfe83eb042fe7b10ca079089e4f4f9b3c8ef99368e90ccb0"
-dependencies = [
- "butane_core 0.5.2-alpha.4 (registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git)",
+ "butane_core",
  "proc-macro2 1.0.49",
  "quote 1.0.23",
  "syn 1.0.107",
@@ -164,41 +141,7 @@ dependencies = [
 
 [[package]]
 name = "butane_core"
-version = "0.5.2-alpha.4"
-dependencies = [
- "bytes",
- "cfg-if",
- "chrono",
- "fake",
- "fallible-iterator",
- "fallible-streaming-iterator",
- "fs2",
- "hex",
- "log",
- "native-tls",
- "once_cell",
- "pin-project",
- "postgres",
- "postgres-native-tls",
- "proc-macro2 1.0.49",
- "quote 1.0.23",
- "r2d2",
- "rand",
- "regex",
- "rusqlite",
- "serde",
- "serde_json",
- "syn 1.0.107",
- "thiserror",
- "utoipa",
- "uuid",
-]
-
-[[package]]
-name = "butane_core"
-version = "0.5.2-alpha.4"
-source = "registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git"
-checksum = "50fc6d68015e3ee008bd5677980c7132203f7aa18b6ef8e82bc45f9568f22d18"
+version = "0.5.2-alpha.5"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -495,7 +438,7 @@ dependencies = [
 name = "example"
 version = "0.1.0"
 dependencies = [
- "butane 0.5.2-alpha.5",
+ "butane",
 ]
 
 [[package]]
@@ -698,7 +641,7 @@ dependencies = [
 name = "getting_started"
 version = "0.1.0"
 dependencies = [
- "butane 0.5.2-alpha.5",
+ "butane",
 ]
 
 [[package]]
@@ -1419,19 +1362,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82e6c8c047aa50a7328632d067bcae6ef38772a79e28daf32f735e0e4f3dd10"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "sha1_smol"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1726,37 +1656,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402bb19d8e03f1d1a7450e2bd613980869438e0666331be3e073089124aa1adc"
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2024452afd3874bf539695e04af6732ba06517424dbf958fdb16a01f3bef6c"
-
-[[package]]
 name = "utoipa"
-version = "3.0.4-alpha.1"
-source = "registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git"
-checksum = "61ab9485d8c623bd8fe1ae35b76e2ba7cfa1d5839077ca514adad5eab10dedfd"
+version = "3.0.4-alpha.2"
 dependencies = [
  "indexmap",
  "serde",
  "serde_json",
- "serde_yaml",
  "utoipa-gen",
 ]
 
 [[package]]
 name = "utoipa-gen"
-version = "3.0.4-alpha.1"
-source = "registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git"
-checksum = "7600699a9234ffa6a4e4a74d2d866661ac77efbb379b62985dc0e2dbf048f16f"
+version = "3.0.4-alpha.2"
 dependencies = [
- "lazy_static",
  "proc-macro-error",
  "proc-macro2 1.0.49",
  "quote 1.0.23",
- "regex",
  "syn 1.0.107",
- "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,10 +92,10 @@ checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
 name = "butane"
-version = "0.5.2-alpha.4"
+version = "0.5.2-alpha.5"
 dependencies = [
- "butane_codegen 0.5.1-alpha.4 (registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git)",
- "butane_core 0.5.2-alpha.3 (registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git)",
+ "butane_codegen 0.5.1-alpha.5 (registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git)",
+ "butane_core 0.5.2-alpha.4 (registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git)",
  "cfg-if",
  "chrono",
  "env_logger",
@@ -117,20 +117,20 @@ dependencies = [
 
 [[package]]
 name = "butane"
-version = "0.5.2-alpha.4"
+version = "0.5.2-alpha.5"
 source = "registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git"
-checksum = "316a6ebe2759753104fa0700e0b70e9023059f572222d8fec618ae7ef9dbd5d7"
+checksum = "7e414a26e5f00315e7c2cf517e654426aa38f6fe15b4e8eb9ae22c1ee071a411"
 dependencies = [
- "butane_codegen 0.5.1-alpha.4 (registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git)",
- "butane_core 0.5.2-alpha.3 (registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git)",
+ "butane_codegen 0.5.1-alpha.5 (registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git)",
+ "butane_core 0.5.2-alpha.4 (registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git)",
 ]
 
 [[package]]
 name = "butane_cli"
-version = "0.5.2-alpha.4"
+version = "0.5.2-alpha.5"
 dependencies = [
  "anyhow",
- "butane 0.5.2-alpha.4 (registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git)",
+ "butane 0.5.2-alpha.5 (registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git)",
  "chrono",
  "clap",
  "quote 1.0.23",
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "butane_codegen"
-version = "0.5.1-alpha.4"
+version = "0.5.1-alpha.5"
 dependencies = [
- "butane_core 0.5.2-alpha.3 (registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git)",
+ "butane_core 0.5.2-alpha.4 (registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git)",
  "proc-macro2 1.0.49",
  "quote 1.0.23",
  "syn 1.0.107",
@@ -151,11 +151,11 @@ dependencies = [
 
 [[package]]
 name = "butane_codegen"
-version = "0.5.1-alpha.4"
+version = "0.5.1-alpha.5"
 source = "registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git"
-checksum = "9a76c1d75605c1f5836174e7f64ccae622dedadfeb1b0ed32f8439a86caba9f2"
+checksum = "557c0c0896f1ba6ecfe83eb042fe7b10ca079089e4f4f9b3c8ef99368e90ccb0"
 dependencies = [
- "butane_core 0.5.2-alpha.3 (registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git)",
+ "butane_core 0.5.2-alpha.4 (registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git)",
  "proc-macro2 1.0.49",
  "quote 1.0.23",
  "syn 1.0.107",
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "butane_core"
-version = "0.5.2-alpha.3"
+version = "0.5.2-alpha.4"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -190,14 +190,15 @@ dependencies = [
  "serde_json",
  "syn 1.0.107",
  "thiserror",
+ "utoipa",
  "uuid",
 ]
 
 [[package]]
 name = "butane_core"
-version = "0.5.2-alpha.3"
+version = "0.5.2-alpha.4"
 source = "registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git"
-checksum = "36488d3cdc86ade64e0c5c7081db5a7e0061bf3e826dab2d7c3be5416dc84fad"
+checksum = "50fc6d68015e3ee008bd5677980c7132203f7aa18b6ef8e82bc45f9568f22d18"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -223,6 +224,7 @@ dependencies = [
  "serde_json",
  "syn 1.0.107",
  "thiserror",
+ "utoipa",
  "uuid",
 ]
 
@@ -493,7 +495,7 @@ dependencies = [
 name = "example"
 version = "0.1.0"
 dependencies = [
- "butane 0.5.2-alpha.4",
+ "butane 0.5.2-alpha.5",
 ]
 
 [[package]]
@@ -696,7 +698,7 @@ dependencies = [
 name = "getting_started"
 version = "0.1.0"
 dependencies = [
- "butane 0.5.2-alpha.4",
+ "butane 0.5.2-alpha.5",
 ]
 
 [[package]]
@@ -773,6 +775,17 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indexmap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+ "serde",
+]
 
 [[package]]
 name = "instant"
@@ -1150,6 +1163,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1379,6 +1416,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82e6c8c047aa50a7328632d067bcae6ef38772a79e28daf32f735e0e4f3dd10"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1674,6 +1724,40 @@ name = "unidecode"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402bb19d8e03f1d1a7450e2bd613980869438e0666331be3e073089124aa1adc"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad2024452afd3874bf539695e04af6732ba06517424dbf958fdb16a01f3bef6c"
+
+[[package]]
+name = "utoipa"
+version = "3.0.4-alpha.1"
+source = "registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git"
+checksum = "61ab9485d8c623bd8fe1ae35b76e2ba7cfa1d5839077ca514adad5eab10dedfd"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "3.0.4-alpha.1"
+source = "registry+https://dl.cloudsmith.io/basic/franklin-ai/rosalind/cargo/index.git"
+checksum = "7600699a9234ffa6a4e4a74d2d866661ac77efbb379b62985dc0e2dbf048f16f"
+dependencies = [
+ "lazy_static",
+ "proc-macro-error",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "regex",
+ "syn 1.0.107",
+ "uuid",
+]
 
 [[package]]
 name = "uuid"

--- a/butane/Cargo.toml
+++ b/butane/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "butane"
-version = "0.5.2-alpha.5"
+version = "0.5.2-alpha.6"
 authors = ["James Oakley <james@electronstudio.org>"]
 edition.workspace = true
 description = "An ORM with a focus on simplicity and on writing Rust, not SQL."
@@ -25,8 +25,8 @@ tls = ["butane_core/tls"]
 uuid = ["butane_core/uuid", "butane_codegen/uuid"]
 
 [dependencies]
-butane_codegen = { version = "0.5.1-alpha.5", registry = "franklin-ai-rosalind" }
-butane_core = { version = "0.5.2-alpha.4", registry = "franklin-ai-rosalind" }
+butane_codegen = { path = "../butane_codegen", version = "0.5.1-alpha.6", registry = "franklin-ai-rosalind" }
+butane_core = { path = "../butane_core", version = "0.5.2-alpha.5", registry = "franklin-ai-rosalind" }
 
 
 [dev-dependencies]

--- a/butane/Cargo.toml
+++ b/butane/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "butane"
-version = "0.5.2-alpha.4"
+version = "0.5.2-alpha.5"
 authors = ["James Oakley <james@electronstudio.org>"]
 edition.workspace = true
 description = "An ORM with a focus on simplicity and on writing Rust, not SQL."
@@ -25,8 +25,8 @@ tls = ["butane_core/tls"]
 uuid = ["butane_core/uuid", "butane_codegen/uuid"]
 
 [dependencies]
-butane_codegen = { version = "0.5.1-alpha.4", registry = "franklin-ai-rosalind" }
-butane_core = { version = "0.5.2-alpha.3", registry = "franklin-ai-rosalind" }
+butane_codegen = { version = "0.5.1-alpha.5", registry = "franklin-ai-rosalind" }
+butane_core = { version = "0.5.2-alpha.4", registry = "franklin-ai-rosalind" }
 
 
 [dev-dependencies]

--- a/butane_cli/Cargo.toml
+++ b/butane_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "butane_cli"
-version = "0.5.2-alpha.4"
+version = "0.5.2-alpha.5"
 authors = ["James Oakley <james@electronstudio.org>"]
 edition = "2018"
 description = "The CLI for the Butane ORM"
@@ -18,7 +18,7 @@ sqlite-bundled = ["butane/sqlite-bundled"]
 
 [dependencies]
 anyhow = "1.0"
-butane = { version = "0.5.2-alpha.4", registry = "franklin-ai-rosalind", features = [
+butane = { version = "0.5.2-alpha.5", registry = "franklin-ai-rosalind", features = [
   "default",
   "sqlite",
   "pg",

--- a/butane_cli/Cargo.toml
+++ b/butane_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "butane_cli"
-version = "0.5.2-alpha.5"
+version = "0.5.2-alpha.6"
 authors = ["James Oakley <james@electronstudio.org>"]
 edition = "2018"
 description = "The CLI for the Butane ORM"
@@ -18,7 +18,7 @@ sqlite-bundled = ["butane/sqlite-bundled"]
 
 [dependencies]
 anyhow = "1.0"
-butane = { version = "0.5.2-alpha.5", registry = "franklin-ai-rosalind", features = [
+butane = { path = "../butane", version = "0.5.2-alpha.6", registry = "franklin-ai-rosalind", features = [
   "default",
   "sqlite",
   "pg",

--- a/butane_codegen/Cargo.toml
+++ b/butane_codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "butane_codegen"
-version = "0.5.1-alpha.4"
+version = "0.5.1-alpha.5"
 authors = ["James Oakley <james@electronstudio.org>"]
 edition.workspace = true
 description = "Macros for Butane. Do not use this crate directly -- use the butane crate."
@@ -13,7 +13,7 @@ datetime = []
 
 [dependencies]
 proc-macro2 = { version = "1.0", default-features = false }
-butane_core = { version = "0.5.2-alpha.3", registry = "franklin-ai-rosalind" }
+butane_core = { version = "0.5.2-alpha.4", registry = "franklin-ai-rosalind" }
 quote = { version = "1.0", default-features = false }
 syn = { version = "1.0", features = [ "extra-traits", "full" ] }
 uuid = { workspace = true, optional = true }

--- a/butane_codegen/Cargo.toml
+++ b/butane_codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "butane_codegen"
-version = "0.5.1-alpha.5"
+version = "0.5.1-alpha.6"
 authors = ["James Oakley <james@electronstudio.org>"]
 edition.workspace = true
 description = "Macros for Butane. Do not use this crate directly -- use the butane crate."
@@ -13,7 +13,7 @@ datetime = []
 
 [dependencies]
 proc-macro2 = { version = "1.0", default-features = false }
-butane_core = { version = "0.5.2-alpha.4", registry = "franklin-ai-rosalind" }
+butane_core = { path = "../butane_core", version = "0.5.2-alpha.5", registry = "franklin-ai-rosalind" }
 quote = { version = "1.0", default-features = false }
 syn = { version = "1.0", features = [ "extra-traits", "full" ] }
 uuid = { workspace = true, optional = true }

--- a/butane_core/Cargo.toml
+++ b/butane_core/Cargo.toml
@@ -52,10 +52,4 @@ fake = { version = "2.5.1-alpha.1", registry = "franklin-ai-rosalind", features 
   "uuid",
 ] }
 rand = "0.8"
-utoipa = { version = "=3.0.4-alpha.1", registry = "franklin-ai-rosalind", features = [
-  "actix_extras",
-  "yaml",
-  "chrono",
-  "uuid",
-  "openapi_extensions",
-] }
+utoipa = { version = "=3.0.4-alpha.1", registry = "franklin-ai-rosalind" }

--- a/butane_core/Cargo.toml
+++ b/butane_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "butane_core"
-version = "0.5.2-alpha.3"
+version = "0.5.2-alpha.4"
 authors = ["James Oakley <james@electronstudio.org>"]
 edition.workspace = true
 description = "Internals for Butane. Do not use this crate directly -- use the butane crate."
@@ -52,3 +52,10 @@ fake = { version = "2.5.1-alpha.1", registry = "franklin-ai-rosalind", features 
   "uuid",
 ] }
 rand = "0.8"
+utoipa = { version = "=3.0.4-alpha.1", registry = "franklin-ai-rosalind", features = [
+  "actix_extras",
+  "yaml",
+  "chrono",
+  "uuid",
+  "openapi_extensions",
+] }

--- a/butane_core/Cargo.toml
+++ b/butane_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "butane_core"
-version = "0.5.2-alpha.4"
+version = "0.5.2-alpha.5"
 authors = ["James Oakley <james@electronstudio.org>"]
 edition.workspace = true
 description = "Internals for Butane. Do not use this crate directly -- use the butane crate."
@@ -52,4 +52,4 @@ fake = { version = "2.5.1-alpha.1", registry = "franklin-ai-rosalind", features 
   "uuid",
 ] }
 rand = "0.8"
-utoipa = { version = "=3.0.4-alpha.1", registry = "franklin-ai-rosalind" }
+utoipa = { path = "../../utoipa/utoipa", version = "=3.0.4-alpha.2", registry = "franklin-ai-rosalind" }

--- a/butane_core/src/fkey.rs
+++ b/butane_core/src/fkey.rs
@@ -209,3 +209,12 @@ impl<T: DataObject> Dummy<Faker> for ForeignKey<T> {
         Self::new_raw()
     }
 }
+
+impl<'__s, T: DataObject + utoipa::ToSchema<'__s>> utoipa::ToSchema<'__s> for ForeignKey<T> {
+    fn schema() -> (
+        &'__s str,
+        utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+    ) {
+        T::schema()
+    }
+}

--- a/butane_core/src/many.rs
+++ b/butane_core/src/many.rs
@@ -187,3 +187,12 @@ impl<T: DataObject> Dummy<Faker> for Many<T> {
         Self::new()
     }
 }
+
+impl<'__s, T: DataObject + utoipa::ToSchema<'__s>> utoipa::ToSchema<'__s> for Many<T> {
+    fn schema() -> (
+        &'__s str,
+        utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+    ) {
+        T::schema()
+    }
+}


### PR DESCRIPTION
Adds utoipa's ToSchema implementation to ForeignKey and Many.

Functionally, we declare the schema components in utoipa's openapi attribute, including the Many<T> and ForeignKey<T> ones, leading to the incorporation of the respective T type in the OpenAPI spec.